### PR TITLE
Fix wildcard route for 404 page

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -90,7 +90,7 @@ console.log(PDFURL)
             <Route exact path="/" element={<HomePage/>}/>
               
             
-            <Route component={NotFound} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
       </AnimatePresence>
         </div>


### PR DESCRIPTION
## Summary
- fix wildcard route in Router.js so that the 404 page works with React Router v6

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521e3ad44c8322ac534cb325e60eb8