### PR TITLE
Fix NotFound route for React Router v6

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -90,7 +90,7 @@ console.log(PDFURL)
             <Route exact path="/" element={<HomePage/>}/>
               
             
-            <Route component={NotFound} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
       </AnimatePresence>
         </div>


### PR DESCRIPTION
## Summary
- update `NotFound` route syntax for React Router v6
- verify build finishes without routing warnings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68521feef6648322b6e2ee20c3bf8589